### PR TITLE
Add MISP playbook: Query Elasticsearch

### DIFF
--- a/db.json
+++ b/db.json
@@ -334,6 +334,24 @@
         ]
     },
     {
+        "description": "Query Elasticsearch for threat intelligence and report sightings in MISP and Mattermost",
+        "tags": [
+            "misp",
+            "playbook",
+            "Threat Intel",
+            "IOC",
+            "elastic",
+            "elasticsearch",
+            "monitoring",
+            "detection",
+            "sighting"
+        ],
+        "link": "https://github.com/MISP/misp-playbooks/blob/main//misp-playbooks/pb_elasticsearch_matches_sightings.ipynb",
+        "authors": [
+            "Koen Van Impe"
+        ]
+    },
+    {
         "description": "Playbook Skeleton",
         "tags": [
             "misp",


### PR DESCRIPTION
Query Elasticsearch for threat intelligence and report sightings in MISP and Mattermost